### PR TITLE
suggestions for columnsSelector logic

### DIFF
--- a/packages/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/packages/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -41,6 +41,8 @@ export interface ColumnDescriptor<T> {
   titleAlign?: "left" | "right" | "center";
   // uniq column identifier
   name: string;
+  // show or hide column by default; It can be overridden by users settings. True if not defined.
+  showByDefault?: boolean;
 }
 
 /**

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -770,7 +770,6 @@ export class StatementDetails extends React.Component<
                 statsByNode,
                 this.props.nodeNames,
                 totalWorkload,
-                ["default"],
               )}
               sortSetting={this.state.sortSetting}
               onChangeSortSetting={this.changeSortSetting}

--- a/packages/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -188,5 +188,9 @@ export const selectStatementsLastError = createSelector(
 
 export const selectColumns = createSelector(
   localStorageSelector,
-  localStorage => localStorage["showColumns/StatementsPage"] || "default",
+  // return array of columns if user customized list of `null` if default set of columns should be used
+  localStorage =>
+    localStorage["showColumns/StatementsPage"]
+      ? localStorage["showColumns/StatementsPage"].split(",")
+      : null,
 );

--- a/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -104,11 +104,12 @@ export const ConnectedStatementsPage = withRouter(
             page: "Statements",
           }),
         ),
-      onColumnsChange: (selected: string) =>
+      onColumnsChange: (selectedColumns: string[]) =>
         dispatch(
           localStorageActions.update({
             key: "showColumns/StatementsPage",
-            value: selected,
+            // isolate transformation from array to string in single place
+            value: selectedColumns.join(","),
           }),
         ),
     }),

--- a/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -20,7 +20,6 @@ storiesOf("StatementsSortedTable", module)
         statements,
         "(internal)",
         calculateTotalWorkload(statements),
-        ["default"],
       )}
       sortSetting={{
         ascending: false,

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -33,7 +33,6 @@ const longToInt = (d: number | Long) => Number(FixLong(d));
 function makeCommonColumns(
   statements: AggregateStatistics[],
   totalWorkload: number,
-  displayColumns?: string[],
 ): ColumnDescriptor<AggregateStatistics>[] {
   const defaultBarChartOptions = {
     classes: {
@@ -69,7 +68,7 @@ function makeCommonColumns(
   // If adding new columns, also add it to src/statementsPage/statementsPage.tsx
   // and if the column should be hidden by default add it to ignoreColumnsOnDefault
   // on that same file.
-  const columns = [
+  const columns: ColumnDescriptor<AggregateStatistics>[] = [
     {
       name: "executionCount",
       title: StatementTableTitle.executionCount,
@@ -83,6 +82,7 @@ function makeCommonColumns(
       className: cx("statements-table__col-database"),
       cell: (stmt: AggregateStatistics) => stmt.database,
       sort: (stmt: AggregateStatistics) => FixLong(Number(stmt.database)),
+      showByDefault: false,
     },
     {
       name: "rowsRead",
@@ -148,13 +148,7 @@ function makeCommonColumns(
         totalWorkload,
     },
   ];
-  if (displayColumns == undefined || displayColumns.includes("default")) {
-    return columns;
-  }
-
-  return columns.filter(option => {
-    return displayColumns.includes(option.name);
-  });
+  return columns;
 }
 
 export interface AggregateStatistics {
@@ -197,7 +191,6 @@ export function makeStatementsColumns(
   selectedApp: string,
   // totalWorkload is the sum of service latency of all statements listed on the table.
   totalWorkload: number,
-  displayColumns?: string[],
   search?: string,
   activateDiagnosticsRef?: React.RefObject<ActivateDiagnosticsModalRef>,
   onDiagnosticsDownload?: (report: IStatementDiagnosticsReport) => void,
@@ -216,7 +209,7 @@ export function makeStatementsColumns(
       sort: stmt => stmt.label,
     },
   ];
-  columns.push(...makeCommonColumns(statements, totalWorkload, displayColumns));
+  columns.push(...makeCommonColumns(statements, totalWorkload));
 
   if (activateDiagnosticsRef) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
@@ -245,7 +238,6 @@ export function makeNodesColumns(
   statements: AggregateStatistics[],
   nodeNames: NodeNames,
   totalWorkload: number,
-  displayColumns?: string[],
 ): ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
@@ -255,7 +247,5 @@ export function makeNodesColumns(
     },
   ];
 
-  return original.concat(
-    makeCommonColumns(statements, totalWorkload, displayColumns),
-  );
+  return original.concat(makeCommonColumns(statements, totalWorkload));
 }

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -35,7 +35,30 @@ export type NodeNames = { [nodeId: string]: string };
 const cx = classNames.bind(styles);
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 
-export const StatementTableTitle = {
+// Single place for column names. Used in table columns and inb columns selector.
+export const statementColumnLabels = {
+  statements: "Statements",
+  database: "Database",
+  executionCount: "Execution Count",
+  rowsRead: "Rows Read",
+  bytesRead: "Bytes Read",
+  statementTime: "Statement Time",
+  transactionTime: "Transaction Time",
+  contention: "Contention",
+  maxMemUsage: "Max Memory",
+  networkBytes: "Network",
+  retries: "Retries",
+  workloadPct: "% of All Runtime",
+  diagnostics: "Diagnostics",
+};
+
+export type StatementTableColumnKeys = keyof typeof statementColumnLabels;
+
+type StatementTableTitleType = {
+  [key in StatementTableColumnKeys]: JSX.Element;
+};
+
+export const StatementTableTitle: StatementTableTitleType = {
   statements: (
     <Tooltip
       placement="bottom"
@@ -55,7 +78,7 @@ export const StatementTableTitle = {
         </>
       }
     >
-      Statements
+      {statementColumnLabels.statements}
     </Tooltip>
   ),
   database: (

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -231,7 +231,6 @@ export class TransactionDetails extends React.Component<
                         aggregatedStatements,
                         "",
                         totalWorkload,
-                        ["default"],
                       )}
                       className={cx("statements-table")}
                       sortSetting={sortSetting}


### PR DESCRIPTION
- avoid filtering columns logic everywhere except columnsSelector component
- columns list has to be derived from columns descriptors
- default options for columns is defined in columns descriptors
- columnsSelector component accepts list of options with initial states and
then tracks its own internal state for selections

note: these changes are intended to highlight some possible improvements only
